### PR TITLE
handler all exception when speech text

### DIFF
--- a/libs/AlexaAndroid/src/main/java/com/willblaschko/android/alexa/AlexaManager.java
+++ b/libs/AlexaAndroid/src/main/java/com/willblaschko/android/alexa/AlexaManager.java
@@ -534,7 +534,7 @@ public class AlexaManager {
 
                                     try {
                                         getSpeechSendText().sendText(mContext, url, token, text, new AsyncEventHandler(AlexaManager.this, callback));
-                                    } catch (IOException e) {
+                                    } catch (Exception e) {
                                         e.printStackTrace();
                                         //bubble up the error
                                         if(callback != null) {


### PR DESCRIPTION
Fix #9
When we call `alexaManager.sendTextRequest(query, requestCallback);` intermediately after init alexaManager then `TextToSpeech` maybe not intialized -> libarary will throw `IllegalStateException("Unable to initialize Text to Speech engine")` which make application crash.
-> we should handler all exception in this case.