### PR TITLE
fix NullPointerException when start-up and send playback related event

### DIFF
--- a/app/src/main/java/com/willblaschko/android/alexavoicelibrary/BaseActivity.java
+++ b/app/src/main/java/com/willblaschko/android/alexavoicelibrary/BaseActivity.java
@@ -161,8 +161,10 @@ public abstract class BaseActivity extends AppCompatActivity implements BaseList
      * https://developer.amazon.com/public/solutions/alexa/alexa-voice-service/reference/audioplayer#PlaybackNearlyFinished Event
      */
     private void sendPlaybackNearlyFinishedEvent(AvsItem item, long offsetInMilliseconds){
-        alexaManager.sendPlaybackNearlyFinishedEvent(item, offsetInMilliseconds, requestCallback);
-        Log.i(TAG, "Sending PlaybackNearlyFinishedEvent");
+        if (item != null) {
+            alexaManager.sendPlaybackNearlyFinishedEvent(item, offsetInMilliseconds, requestCallback);
+            Log.i(TAG, "Sending PlaybackNearlyFinishedEvent");
+        }
     }
 
     /**

--- a/app/src/main/java/com/willblaschko/android/alexavoicelibrary/BaseActivity.java
+++ b/app/src/main/java/com/willblaschko/android/alexavoicelibrary/BaseActivity.java
@@ -179,8 +179,10 @@ public abstract class BaseActivity extends AppCompatActivity implements BaseList
      * https://developer.amazon.com/public/solutions/alexa/alexa-voice-service/reference/audioplayer#PlaybackNearlyFinished Event
      */
     private void sendPlaybackFinishedEvent(AvsItem item){
-        alexaManager.sendPlaybackFinishedEvent(item, requestCallback);
-        Log.i(TAG, "Sending SpeechFinishedEvent");
+        if (item != null) {
+            alexaManager.sendPlaybackFinishedEvent(item, requestCallback);
+            Log.i(TAG, "Sending SpeechFinishedEvent");
+        }
     }
 
     //async callback for commands sent to Alexa Voice

--- a/libs/AlexaAndroid/src/main/java/com/willblaschko/android/alexa/AlexaManager.java
+++ b/libs/AlexaAndroid/src/main/java/com/willblaschko/android/alexa/AlexaManager.java
@@ -652,7 +652,7 @@ public class AlexaManager {
      * @param callback
      */
     public void sendPlaybackNearlyFinishedEvent(AvsItem item, final long offsetMilliseconds, final AsyncCallback<AvsResponse, Exception> callback){
-        if (item != null) {
+        if (!(item instanceof AvsSpeakItem)) {
             sendEvent(Event.getPlaybackNearlyFinishedEvent(item.getToken(), offsetMilliseconds), callback);
         }
     }

--- a/libs/AlexaAndroid/src/main/java/com/willblaschko/android/alexa/AlexaManager.java
+++ b/libs/AlexaAndroid/src/main/java/com/willblaschko/android/alexa/AlexaManager.java
@@ -652,7 +652,9 @@ public class AlexaManager {
      * @param callback
      */
     public void sendPlaybackNearlyFinishedEvent(AvsItem item, final long offsetMilliseconds, final AsyncCallback<AvsResponse, Exception> callback){
-        sendEvent(Event.getPlaybackNearlyFinishedEvent(item.getToken(), offsetMilliseconds), callback);
+        if (item != null) {
+            sendEvent(Event.getPlaybackNearlyFinishedEvent(item.getToken(), offsetMilliseconds), callback);
+        }
     }
 
 


### PR DESCRIPTION
Thanks a lot for your contribution!  
when i start-up and to authorize, appear the following error.
![2](https://cloud.githubusercontent.com/assets/7686706/17471259/86ba390c-5d75-11e6-95c5-2c8157404d00.png)
may be fixed as my pull request.

However,  there may be other issues. i send a request to AVS and play back the response audio. After that, there will be a pop:INTERNAL_SERVICE_EXCEPTION:Request could not be executed due to an internal  service error.
Des it related to `audio player callback` or  others addition?